### PR TITLE
Streaming line processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "heap-analyzer",
+  "version": "0.0.0",
+  "homepage": "https://github.com/tenderlove/heap-analyzer",
+  "authors": [],
+  "license": "",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "client-line-navigator": "git@github.com:anpur/client-line-navigator.git"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -66,14 +66,31 @@
     </div>
   </div>
 
-  <div id="instructions" class="row top-buffer">
-    <div class="col-sm-12 form-inline">
-      Getting a heap dump of your Rails application just after boot:
-      <pre>$ echo "require 'objspace'; ObjectSpace.trace_object_allocations_start" &gt; x.rb
+  <div id="instructions" class="top-buffer">
+    <div class="row">
+      <div class="col-sm-12 form-inline">
+        Getting a heap dump of your Rails application just after boot:
+        <pre>
+$ echo "require 'objspace'; ObjectSpace.trace_object_allocations_start" &gt; x.rb
 $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; puts ObjectSpace.dump_all.path'</pre>
-      This will print a file name that contains JSON representing your heap.  Upload that file.
+        This will print a file name that contains JSON representing your heap.  Upload that file.
+      </div>
+    </div>
+
+    <br/>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="progress" id="upload-progress-bar" style="display: none;">
+          <div class="progress-bar" role="progressbar" aria-valuenow="0"
+          aria-valuemin="0" aria-valuemax="100" style="width:0%">
+            70%
+          </div>
+        </div>
+      </div>
     </div>
   </div>
+
 
   <div class="row top-buffer">
     <div class="col-sm-6">
@@ -95,6 +112,8 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
 
   var plist = $("#parent-list").html();
   var plistTemplate = Handlebars.compile(plist);
+
+  var $uploadProgressBar = $("#upload-progress-bar");
 
   var objects;
   var objIndex;
@@ -257,6 +276,15 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
     });
   }
 
+  function updateFileProcessingProgressBar(percentageToCompletion) {
+    var percentageText = percentageToCompletion + "%";
+    $uploadProgressBar.show().find(".progress-bar")
+                                    .attr("aria-valuenow", percentageToCompletion)
+                                    .css("width", percentageText)
+                                    .text(percentageText);
+
+  }
+
   function readHeap(file) {
     var fileNavigator = new FileNavigator(file);
 
@@ -265,6 +293,8 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
 
     // Start reading all files
     fileNavigator.readSomeLines(0, function linesReadHandler(err, index, lines, eof, progress) {
+        updateFileProcessingProgressBar(progress);
+
         // Error happened
         if (err) {
           console.error("Error while reading files", err);

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.2/handlebars.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+  <script src="bower_components/client-line-navigator/line-navigator.min.js"></script>
+  <script src="bower_components/client-line-navigator/file-navigator.min.js"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <script id="object-list" type="text/x-handlebars-template">
     <table class="table">
@@ -256,34 +258,46 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
   }
 
   function readHeap(file) {
-    var reader = new FileReader();
+    var fileNavigator = new FileNavigator(file);
 
-    reader.onloadend = function(evt) {
-      if (evt.target.readyState == FileReader.DONE) {
-        $("#instructions").hide();
-        var lines = evt.target.result.split("\n");
-        objects = [];
-        objIndex    = {};
+    objects = [];
+    objIndex = {};
 
-        lines.forEach(function(line) {
-            if (line.length > 0) {
-              var obj = JSON.parse(line);
-              objIndex[obj.address] = obj;
-              objects.push(obj);
-            }
-        });
+    // Start reading all files
+    fileNavigator.readSomeLines(0, function linesReadHandler(err, index, lines, eof, progress) {
+        // Error happened
+        if (err) {
+          console.error("Error while reading files", err);
+          return;
+        }
 
-        var typeInfo = objectsByType(objects);
-        plotTypes($('#type-info'), typeInfo);
+        // Reading lines
+        for (var i = 0; i < lines.length; i++) {
+            var lineIndex = index + i;
+            var line = lines[i];
 
-        var genInfo = objectsByGeneration(objects);
-        plotGeneration($('#generation-info'), genInfo);
+            // Parse each line and add it to the index
+            var obj = JSON.parse(line);
+            objIndex[obj.address] = obj;
+            objects.push(obj);
+        }
 
-        console.log("done");
-      }
-    };
+        // End of file
+        if (eof) {
+          $("#instructions").hide();
 
-    reader.readAsText(file);
+          var typeInfo = objectsByType(objects);
+          plotTypes($('#type-info'), typeInfo);
+
+          var genInfo = objectsByGeneration(objects);
+          plotGeneration($('#generation-info'), genInfo);
+
+          return;
+        }
+
+        // Reading next chunk, adding number of lines read to first line in current chunk
+        fileNavigator.readSomeLines(index + lines.length, linesReadHandler);
+    });
   }
 
 document.querySelector('.readButton').addEventListener('click', function(e) {


### PR DESCRIPTION
Hi,

After measuring the performance of uploading heap dump of 74mb (empty rails app),
I found out that the most expensive/blocking code is the processing of the lines.

In this pull request:
- I move to streaming lines processing - it's much faster and dosen't block the ui
- Adding progress bar for showing the processing status
- Adding bower file to add the "client-line-navigator" dependency, I can submit a pull request for moving all other resources to bower If you want.
