### PR TITLE
Faster parents lookup

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ Handlebars.registerHelper('allocInfo', function(file, line) {
 });
 
 Handlebars.registerHelper('fetchClassName', function(classAddress) {
-  return objIndex[classAddress].name;
+  return objIndex[+classAddress].name;
 });
 
 function objectsByType(objs) {

--- a/app.js
+++ b/app.js
@@ -227,6 +227,7 @@ function readHeap(file) {
 
   var objects = [];
   objIndex = {};
+  parentsIndex = {};
 
   clearErrors();
 

--- a/app.js
+++ b/app.js
@@ -11,6 +11,11 @@ var objIndex = {};
 // Map where the key is child object address, and the value is list parent's addres
 var parentsIndex = {};
 
+function toAddress(number) {
+  return '0x' + number.toString(16);
+}
+
+
 function addParents(element) {
   var address = +element.getAttribute("data-address");
   var parentsAddress = parentsIndex[address];
@@ -21,7 +26,7 @@ function addParents(element) {
     if (parents.length > 0) {
       var data = { objects: parents.sort(function(a, b) { return b.memsize - a.memsize; }) };
       var innerTable = template(data);
-      var newTr = plistTemplate({ list: innerTable, "address": address });
+      var newTr = plistTemplate({ list: innerTable, "address": toAddress(address) });
       $(element).after(newTr);
     }
   }

--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ var plistTemplate = Handlebars.compile(plist);
 
 var $uploadProgressBar = $("#upload-progress-bar");
 
-var objects = [];
 var objIndex = {};
 
 // Map where the key is child object address, and the value is list parent's addres
@@ -226,7 +225,7 @@ function clearErrors() {
 function readHeap(file) {
   var fileNavigator = new FileNavigator(file);
 
-  objects = [];
+  var objects = [];
   objIndex = {};
 
   clearErrors();

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ var objIndex = {};
 var parentsIndex = {};
 
 function addParents(element) {
-  var address = element.getAttribute("data-address");
+  var address = +element.getAttribute("data-address");
   var parentsAddress = parentsIndex[address];
 
   if(parentsAddress !== undefined) {
@@ -257,19 +257,19 @@ function readHeap(file) {
         return;
       }
       
-      objIndex[obj.address] = obj;
+      objIndex[+obj.address] = obj;
       objects.push(obj);
 
       // add object to the parents index
       // key - child, value = parents
       obj.references = obj.references || [];
 
-      var parentAddress = obj.address;
+      var parentAddress = +obj.address;
       obj.references.forEach(function(childAddress) {
-        var indexValue = parentsIndex[childAddress] || [];
+        var indexValue = parentsIndex[+childAddress] || [];
         indexValue.push(parentAddress);
 
-        parentsIndex[childAddress] =  indexValue;
+        parentsIndex[+childAddress] =  indexValue;
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     width: 600px;
     height: 400px;
   }
+
   .top-buffer { margin-top:20px; }
 
   /*
@@ -40,6 +41,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dc/1.7.4/dc.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 
 <body>
@@ -154,12 +156,12 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
     </tbody>
     </table>
   </script>
-  
+
   <script id="parent-list" type="text/x-handlebars-template">
     <tr data-parentsof="{{address}}">
       <td>Parents of {{address}}</td>
       <td colspan="4">{{{list}}}</td>
-      <tr>
+    <tr>
   </script>
 
   <!--

--- a/index.html
+++ b/index.html
@@ -30,18 +30,8 @@
     -webkit-transition: none !important;
   }
   </style>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <script src="https://code.highcharts.com/highcharts.js"></script>
-  <script src="https://code.highcharts.com/modules/exporting.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.2/handlebars.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-  <script src="bower_components/client-line-navigator/line-navigator.min.js"></script>
-  <script src="bower_components/client-line-navigator/file-navigator.min.js"></script>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dc/1.7.4/dc.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@ $ RAILS_ENV=production ruby -I. -rx -e'require "config/environment"; GC.start; p
     <tr>
   </script>
 
+
   <!--
     Scripts
   -->


### PR DESCRIPTION
Hi,

Improving the performance of parents lookup by adding parents index which map children to it's parents.
I have also removed the "objects" global variable to save some memory and now we are using combination of object index and parents index.

Now the showing of parents is slow only because of big tables, I decreased the lookup from 100ms~ to 6ms~ (checked using console.time and clicked multiple rows).
